### PR TITLE
set devfile's schemaVersion to 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: python-hello-world
 components:


### PR DESCRIPTION
Updates devfile's schemaVersion to 2.2.2

Related issue: https://github.com/eclipse/che/issues/21985

![screenshot-devspaces apps sandbox-stage gb17 p1 openshiftapps com-2024 02 01-16_05_52](https://github.com/devspaces-samples/python-hello-world/assets/1271546/8660835c-114e-4947-908a-f4a680226505)




